### PR TITLE
Stop using captions until fix propagated.

### DIFF
--- a/release_workflows/fx_beta_release.rst
+++ b/release_workflows/fx_beta_release.rst
@@ -2,9 +2,9 @@ Firefox Beta Release
 ====================
 .. seealso:: :ref:`Disclaimer <workflow_disclaimer>`
 
+..  :caption: Beta Releases
 .. actdiag::
     :desctable:
-    :caption: Beta Releases
     :alt: Inter-team handoffs for Public Releases
     :name: Figure3
 

--- a/release_workflows/fx_ga_release.rst
+++ b/release_workflows/fx_ga_release.rst
@@ -2,9 +2,9 @@ Firefox GA Release
 ==================
 .. seealso:: :ref:`Disclaimer <workflow_disclaimer>`
 
+.. :caption: GA Releases
 .. actdiag::
     :desctable:
-    :caption: GA Releases
     :alt: Inter-team handoffs for Public Releases
     :name: Figure1
 


### PR DESCRIPTION
sphinx-doc/sphinx#1788 is fixed in tree, but not released yet. For our
purposes, we need it deployed on read-the-docs.