### PR TITLE
Improve releaseduty docs; add adhoc signing reference

### DIFF
--- a/procedures/release-duty/index.rst
+++ b/procedures/release-duty/index.rst
@@ -36,6 +36,17 @@ tools
 Communication
 -------------
 
+Slack Channels
+~~~~~~~~~~~~~~~
+
+Join Mozilla's Slack network using information from `the wiki <https://wiki.mozilla.org/NDA-Slack>`__
+
+You ought to be present and pay attention to conversations happening in:
+
+* **#releaseduty-mobile** (where `mobile` and other Github releng-backedup automation projects's teams raise issues)
+* **#releng-notifications** (where automation notifications are going, useful to know the state of our automation infrastructure state)
+* **#taskcluster-cloudops** (where CloudOps double-checks with RelEng whether it's safe to deploy changes or not on their side)
+
 Matrix Channels
 ~~~~~~~~~~~~~~~
 
@@ -229,7 +240,7 @@ Other useful resources
 Glossary
 --------
 
-*  WNP - The “What's New Page” can be set to appear after an upgrade, to tell end-users of any changes in the browser they should be aware of. 
+*  WNP - The “What's New Page” can be set to appear after an upgrade, to tell end-users of any changes in the browser they should be aware of.
 *  FF - Firefox
 *  TB - Thunderbird
 *  b1, b2, etc - beta release 1, beta release 2, etc
@@ -305,7 +316,7 @@ published.
 
 In the beta cycle, ``Firefox`` and ``Devedition`` are different products
 built based on the same in-tree revision. Their functionality is the
-same but branding options differ. 
+same but branding options differ.
 
 11. What do the terms ``releases directory``, ``mirrors`` and ``CDN`` mean?
 

--- a/signing/adhoc_signing.rst
+++ b/signing/adhoc_signing.rst
@@ -1,0 +1,8 @@
+Adhoc signing
+=============
+
+For more information follow `adhoc-signing repo docs`_.
+This document is for Release Engineering, on how to maintain this repo,
+and how to deal with ad-hoc signing requests.
+
+.. _adhoc-signing repo docs: https://github.com/mozilla-releng/adhoc-signing/blob/master/docs/releng.md

--- a/signing/index.rst
+++ b/signing/index.rst
@@ -9,6 +9,8 @@ Contents:
     Manually-sign-Android-APKs.md
     create_new_release_signing_key.md
     notarization.md
+    adhoc_signing.md
+
 
 
 

--- a/signing/index.rst
+++ b/signing/index.rst
@@ -9,7 +9,7 @@ Contents:
     Manually-sign-Android-APKs.md
     create_new_release_signing_key.md
     notarization.md
-    adhoc_signing.md
+    adhoc_signing.rst
 
 
 


### PR DESCRIPTION
As per our discussions in `Process and Handling of Firefox-CI administration requests` document.