### PR TITLE
add xpi signing doc links

### DIFF
--- a/addons/index.rst
+++ b/addons/index.rst
@@ -1,0 +1,8 @@
+Addons
+======
+
+.. toctree::
+    :maxdepth: 2
+
+    langpacks
+    xpi-signing

--- a/addons/langpacks.rst
+++ b/addons/langpacks.rst
@@ -1,5 +1,5 @@
-Addon Submission Pipeline
-=========================
+Langpack Submission Pipeline
+============================
 
 Terminology:
 ------------

--- a/addons/xpi-signing.rst
+++ b/addons/xpi-signing.rst
@@ -1,0 +1,7 @@
+XPI Signing Pipeline
+====================
+
+We support signing privileged webextensions and system addons in taskcluster,
+through Shipit.
+
+See the docs for `adding a new xpi <https://github.com/mozilla-extensions/xpi-manifest/blob/master/docs/adding-a-new-xpi.md>`__ and `releasing a xpi <https://github.com/mozilla-extensions/xpi-manifest/blob/master/docs/releasing-a-xpi.md>`__.

--- a/index.rst
+++ b/index.rst
@@ -32,7 +32,7 @@ Contents:
    taskcluster/index.rst
    hosts.rst
    software.rst
-   addons/addons.rst
+   addons/index.rst
    Balrog & Updates <balrog/index.rst>
    Signing <signing/index.rst>
    releng_changelog


### PR DESCRIPTION
I also rename the `Addon Submission Pipeline` to `Langpack submission pipeline`, just to clarify and differentiate from the xpi signing pipeline.