### PR TITLE
Gradle: Do no install it globally

### DIFF
--- a/procedures/mobile_automation_setup.rst
+++ b/procedures/mobile_automation_setup.rst
@@ -421,7 +421,8 @@ Setting up taskgraph for mobile is similar to setting up taskgraph for any
 standalone project, especially github standalone projects: install
 `taskgraph <https://hg.mozilla.org/ci/taskgraph>`__ in a virtualenv.
 
-However, you also need to install ``gradle``.
+⚠️ You shouldn't install ``gradle`` globally on your system. The `./gradlew` scripts in each mobile repo define
+specific gradle versions and are in charge of installing it locally.
 
 On mac, using homebrew:
 
@@ -434,14 +435,10 @@ On mac, using homebrew:
 
     brew cask install android-sdk
 
-3. Install gradle::
-
-    brew install gradle
-
-4. Make sure you're pointing to the right java::
+3. Make sure you're pointing to the right java::
 
     # in your .zshrc or .bashrc
-    export JAVA_HOME=/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home
+    export JAVA_HOME="$(/usr/libexec/java_home -v 1.8)"
 
     # After sourcing that file, you should get the following version:
     # > $JAVA_HOME/bin/java -version
@@ -449,7 +446,7 @@ On mac, using homebrew:
     # OpenJDK Runtime Environment (AdoptOpenJDK)(build 1.8.0_265-b01)
     # OpenJDK 64-Bit Server VM (AdoptOpenJDK)(build 25.265-b01, mixed mode)
 
-5. test it::
+4. test it::
 
     # In, say, an android-components clone, this should work:
     ./gradlew tasks --scan


### PR DESCRIPTION
Follows https://github.com/mozilla/build-relengdocs/pull/49 up. 