### PR TITLE
Add some notes about issues with bouncer-check when adding a new pack…

### DIFF
--- a/procedures/adding_package_format.rst
+++ b/procedures/adding_package_format.rst
@@ -1,0 +1,28 @@
+
+Adding a package format
+=======================
+
+There are some gotchas to pay attention to when adding a new package format, in
+particular related to bouncer.
+
+The `release-bouncer-check` and `cron-bouncer-check` tasks use the
+configuration files in `testing/mozharness/configs/releases/bouncer_*.py`,
+which include 2 kinds of products: versioned ones, and `-latest` ones.
+
+Because the latter do not exist in bouncer until after the first release with
+that package format is out, they should not be added to the `bouncer-check`
+configs until after the first release with them is shipped.
+
+For example, if a new format `foo` is added in the `96.0a1` nightly cycle:
+
+* `Firefox-%(version)-foo` can be added to the `beta` and `release` configs
+  at the same time
+
+* `Firefox-beta-foo-latest` can't be added to `bouncer_firefox_beta.py` (and
+  uplifted) until after `96.0b1` is released
+
+* `Firefox-foo-latest` should be
+  added and uplifted as soon as possible after `96.0` ships (so that if
+  anything turns out to be wrong, `cron-bouncer-check` flags it ASAP), but not
+  before (otherwise `release-bouncer-check` will fail and block the release).
+

--- a/procedures/index.rst
+++ b/procedures/index.rst
@@ -18,6 +18,7 @@ Procedures that don't easily fit elsewhere.
     Transitioning.rst
     accounts_setup
     mobile_automation_setup
+    adding_package_format
     misc-operations/*
 
 .. vim: nospell :


### PR DESCRIPTION
…age format

I wrote this in response to the bustage we faced when adding msix in Firefox 94.

I'm not sure if this makes sense and where it should live, feedback welcome.