### PR TITLE
Remove references to the standalone ci-admin repo

### DIFF
--- a/procedures/mobile_automation_setup.rst
+++ b/procedures/mobile_automation_setup.rst
@@ -52,18 +52,14 @@ match between the build and the hook that starts the build.
 
 5.  Create and update permissions in ``ci-configuration``.
 
-    1. Install ``ci-admin`` if you haven't already
-
-        1. ``hg clone https://hg.mozilla.org/ci/ci-admin/``
-        2. Set up a ``virtualenv`` and install dependencies
-
     1. ``hg clone https://hg.mozilla.org/ci/ci-configuration/``
-    2. Update ``projects.yml`` and ``grants.yml`` to add permissions for ``$project``
+    2. Set up a ``virtualenv`` and install dependencies
+    3. Update ``projects.yml`` and ``grants.yml`` to add permissions for ``$project``
 
         - If you have schedule-based automation, add the ``taskgraph-cron`` feature and set ``cron_targets`` in ``projects.yml``. Additionally, create
           a ``.cron.yml`` file to your repository like the one in `fenix <https://github.com/mozilla-mobile/fenix/blob/master/.cron.yml>`__
-    3. Submit your patch for review with `moz-phab <https://github.com/mozilla-conduit/review>`__
-    4. Once it's landed, update to the new revision and apply it
+    4. Submit your patch for review with `moz-phab <https://github.com/mozilla-conduit/review>`__
+    5. Once it's landed, update to the new revision and apply it
 
         1. ``ci-admin diff --environment=production``
         2. If there's no surprises in the diff, apply it: ``ci-admin apply --environment=production``

--- a/taskcluster/scopes.rst
+++ b/taskcluster/scopes.rst
@@ -33,7 +33,7 @@ Ci-configuration
 
 We grant scopes to clients and roles. These are defined in the `ci-configuration repo <https://hg.mozilla.org/ci/ci-configuration/>`__; view the `README <https://hg.mozilla.org/ci/ci-configuration/file/tip/README.md>`__.
 
-We test, diff, and apply these configuration changes using the `ci-admin repo <https://hg.mozilla.org/ci/ci-admin/>`__; view the `README <https://hg.mozilla.org/ci/ci-admin/file/tip/README.md>`__.
+The ci-configuration repo also contains the `ci-admin` management tool which we use to test, diff, and apply the configuration changes.
 
 Conventions
 -----------


### PR DESCRIPTION
It was merged into ci-configuration last year.