### PR TITLE
Fix documentation of worker-type overrides in mach try

### DIFF
--- a/gecko_tests/new_config.rst
+++ b/gecko_tests/new_config.rst
@@ -36,7 +36,7 @@ There are a few exceptions here:
   * duplicated jobs (i.e. fission, a11y-checks), you can just run those specific tasks:
       ``./mach try fuzzy --no-artifact -q 'test-windows fission --rebuild 5``
   * new OS/hardware (i.e. aarch64, os upgrade), you need to reference the new hardware, typically this is with ``--worker-override``:
-      ``./mach try fuzzy --no-artifact -q 'test-windows --rebuild 5 --worker-override t-win10-64=t-win10-64-1903``
+      ``./mach try fuzzy --no-artifact -q 'test-windows --rebuild 5 --worker-override t-win10-64=gecko-t/t-win10-64-1903``
 
     * the risk here is a scenario where hardware is limited, then ``--rebuild 5`` will create too many tasks and some will expire.
     * in low hardware situations, either run a subset of tests (i.e. web-platform-tests, mochitest), or ``--rebuild 2`` and repeat.

--- a/procedures/release-duty/desktop/staging-release.rst
+++ b/procedures/release-duty/desktop/staging-release.rst
@@ -99,7 +99,7 @@ amended. More information on this can be found in the
 `scriptworker-scripts documentation`_. One can either manually change
 the intree kind's config to that specific worker-type, or can simply pass an
 argument to aforementioned command to make the replacement,
-e.g. ``mach try scriptworker TASK-TYPE --release-type beta --worker-override <alias>=<suffix>``,
+e.g. ``mach try scriptworker TASK-TYPE --release-type beta --worker-suffix <alias>=<suffix>``,
 where ``TASK-TYPE`` is chosen from one of the
 ``mach try scriptworker list`` returns and ``alias`` comes from the
 taskcluster ci config `file`_). For example, running the beetmover jobs against the most recent beta
@@ -107,7 +107,7 @@ release, but on the DEV worker-type:
 
 ::
 
-   mach try scriptworker beetmover-candidates --release-type beta --worker-override beetmover=gecko-1-beetmover-dev
+   mach try scriptworker beetmover-candidates --release-type beta --worker-suffix beetmover=-dev
 
 .. _scriptworker selector: https://firefox-source-docs.mozilla.org/tools/try/selectors/scriptworker.html?highlight=scriptworker
 .. _here: https://hg.mozilla.org/mozilla-central/file/tip/tools/tryselect/selectors/scriptworker.py#l18


### PR DESCRIPTION
`mach try --worker-override` expects a worker-pool name, i.e.
`{provisioner}/{worker-type}`, not just `{worker-type}`.

For the special case of using dev scriptworkers, suggest `--worker-suffix` instead.