### PR TITLE
Update the new ESR docs based on my experience with ESR140

### DIFF
--- a/how-to/releaseduty/merge-duty/merge_new_esr_branch.rst
+++ b/how-to/releaseduty/merge-duty/merge_new_esr_branch.rst
@@ -121,16 +121,16 @@ Task list and known dependencies
     asking for the esrXX repository to be added to Phabricator, as
     mozilla-esrXX, tagged for uplifts, and hooked up to code-review-bot
 
-18. Once XX becomes the current beta, run a beta as esr simulation to
+18. Early in the XX nightly cycle, run a ESRXX staging release to identify
+    release automation failures (then fix and repeat as necessary). (`./mach
+    try release --version XX.0esr --migration central-to-beta --migration
+    beta-to-release --migration release-to-esr --disable-pgo`)
+
+19. Once XX becomes the current beta, run a beta as esr simulation to
     identify permanent build and test failures. (`./mach try release
     --disable-pgo -v XX.0esr --migration beta-to-release --migration
     release-to-esr --tasks release-sim`). Don't hesitate to ask sheriffs for
     help with classification of tests failures.
-
-19. Early in the XX nightly cycle, run a ESRXX staging release to identify
-    release automation failures (then fix and repeat as necessary). (`./mach
-    try release --version XX.0esr --migration central-to-beta --migration
-    beta-to-release --migration release-to-esr --disable-pgo`)
 
 20. Add esrXX to the `legacy approval mapping for bmo.
     <https://github.com/mozilla-bteam/bmo/blob/ed603350fcf9822672555d1822f2d9f51db305e5/extensions/PhabBugz/lib/Util.pm#L46-L52>`__


### PR DESCRIPTION
Updating gecko_taskgraph depends on balrog since you need the rule IDs.

You can run the esr staging early in the nightly cycle, it's unlikely that something will break for ESRs during that cycle as it'll be on people's mind, unlike the rest of the year. And this avoids having to uplift patches later.

Likewise, the beta as esr release simulation should be done somewhat early in the beta cycle, this will avoid potential uplifts to the esr branch to fix said tests since they can be fixed during the beta cycle instead.

I also added some command examples because they're not necessarily easy to figure out and if someone else has to do it for the first time, they'll be happy to find them here.

Added a new step required for the uplift approval mapping

Added a reference to ronin_puppet in the scriptworker bump. It's something that I didn't think about when I was updating scriptworker everywhere else.

Figuring out how to use the lando CLI was also a huge pain so I added some documentation about that too.