### PR TITLE
minor fixes for esr documentation

### DIFF
--- a/how-to/releaseduty/desktop/esr-to-esr-updates.rst
+++ b/how-to/releaseduty/desktop/esr-to-esr-updates.rst
@@ -5,8 +5,8 @@ Overview
 --------
 
 When an ESR version is end-of-life'd we need to update still supported users to
-the next ESR version. This usually happens with the x.3.0 release of the new ESR
-version, eg: 78.3.0esr. The general steps to this process are the same every time
+the next ESR version. This usually happens with the x.5.0 release of the new ESR
+version, eg: 153.5.0esr. The general steps to this process are the same every time
 but the specifics change -- so it's important to check your work with other members
 of the team, as well as RelMan, and for QA to test.
 
@@ -86,9 +86,9 @@ have been superceded by the new ``esr*`` rules.
 Bouncer and EOL'ing the old ESR branch
 --------------------------------------
 
-This includes a couple of things, before and after building/shipping X.3.0esr.
+This includes a couple of things, before and after building/shipping X.5.0esr. (Note that some of the examples date from a time when X.3.0esr was the cut over, which is the reason for the version difference.)
 
-Before GTB of the X.3.0esr release
+Before GTB of the X.5.0esr release
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 1. The new ESR branch needs to become the new default in a couple of
@@ -104,7 +104,7 @@ Before GTB of the X.3.0esr release
    `this <https://phabricator.services.mozilla.com/D88618>`__ to remove
    all occurrences of esr68 and adjust configuration.
 
-After X.3.0esr is shipped
+After X.5.0esr is shipped
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 1. Ship-it holds information that gets propagated to `product-details`_
@@ -119,8 +119,9 @@ After X.3.0esr is shipped
    singular release so it needs to be properly updated to reflect the
    one one. For example once we shipped esr78, we pushed
    `this <https://phabricator.services.mozilla.com/D88619>`__ on esr78.
+   `esr-next` entries should also stop being checked at this time.
 
-3. EOL-ing the old ESR branch. Once X.3.0 is shipped, we can stop
+3. EOL-ing the old ESR branch. Once X.5.0 is shipped, we can stop
    generating CI for the old branch. That includes removing all the cron
    jobs, including but not limited to: periodic updates, nightlies,
    bouncer checks, searchfox, etc. For retiring and EOL-ing esr68 we’ve

--- a/how-to/releaseduty/merge-duty/merge_new_esr_branch.rst
+++ b/how-to/releaseduty/merge-duty/merge_new_esr_branch.rst
@@ -157,26 +157,26 @@ Task list and known dependencies
     mozilla-esrXX (maybe trigger the hook manually first)
 
 28. After the last scheduled release from the previous ESR branch, and before
-    the first standalone esrXX release (typically XX.3.0), make esrXX not
+    the first standalone esrXX release (typically XX.5.0), make esrXX not
     next-esr: update the release-bouncer-aliases task to update the main esr
     bouncer aliases, and run update-verify from older major versions (adjust
     last-manifest)
 
-29. Before gtb for XX.3.0 (beginning of RC week for XX+3), update balrog rules
+29. Before gtb for XX.5.0 (beginning of RC week for XX+5), update balrog rules
     on esr-localtest and esr-cdntest to allow updates to esrXX; check rules on
     the release channel, and check with release management for any necessary
     watershed and/or desupport rules.
 
-30. At XX.3.0 release time, update the rules on balrog's esr channel (similar to 26).
+30. At XX.5.0 release time, update the rules on balrog's esr channel (similar to 26).
 
 31. Around the same time, update shipit's `CURRENT_ESR` and `ESR_NEXT` config
     variables, and rebuild product-details.
 
-32. Shortly after the XX.3.0 release, update the cron-bouncer-check task's
+32. Shortly after the XX.5.0 release, update the cron-bouncer-check task's
     config on esrXX to look at `FIREFOX_ESR` instead of `FIREFOX_ESR_NEXT`.
 
-33. Some time later (maybe soon after the XX.3.0 release to avoid forgetting),
-    stop running update-verify-next on esrXX, and stop updating the esr-next
-    aliases
+33. Some time later (maybe soon after the XX.5.0 release to avoid forgetting),
+    stop running update-verify-next on esrXX, stop updating the esr-next
+    aliases, and remove them from bouncer check.
 
 34. Close the meta bug and have some tea. :)


### PR DESCRIPTION
* XX.5.0 is now the cut-over release from esr to esr-next (I would've liked to update the example links in those docs...but we haven't done this yet for 153.5.0esr.)
* Update new esr branch documentation to recommend removing `esr-next` from bouncer check configs.